### PR TITLE
fix: AWS workaround

### DIFF
--- a/get_controller_addresses.py
+++ b/get_controller_addresses.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python
+import json
+import subprocess
+
+# Workaround for:
+# https://github.com/juju/terraform-provider-juju/issues/573
+#
+# Deploying on AWS intermittently fails with i/o timeouts as the Juju
+# Terraform provider returns inaccessible local IP addresses in the list of
+# API controllers. Work around by determining if the current cloud is 'aws'
+# and set environment variable 'JUJU_CONTROLLER_ADDRESSES' to the non-local
+# endpoint(s) if so.
+#
+# For example, controller configuration:
+#
+#   cloud: aws
+#   api_endpoints = ['44.192.113.5:17070', '172.31.11.216:17070',
+#                    '252.11.216.1:17070']
+#
+# results in:
+#
+#   export JUJU_CONTROLLER_ADDRESSES=44.192.113.5:17070
+
+# Check if deploying on AWS
+result = subprocess.check_output("juju show-controller --format json".split(),
+                                 stderr=subprocess.STDOUT, text=True)
+juju_config = json.loads(result)
+# Expect dictionary with single key corresponding to current controller name
+controller_name = list(juju_config.keys())[0]
+cloud = juju_config[controller_name]["details"]["cloud"]
+
+if cloud == "aws":
+    # Filter out local IP addresses from list of all API endpoints
+    endpoints = juju_config[controller_name]["details"]["api-endpoints"]
+    valid_endpoints = "" # Terraform requires external data as string type
+    for endpoint in endpoints:
+        # Local IPs defined as those in 172.x and 252.x ranges
+        if not(endpoint.startswith(("172","252"))):
+            valid_endpoints += endpoint + ","
+
+    # Output in JSON format expected by Terraform
+    valid_endpoints = valid_endpoints.rstrip(",")
+    print(json.dumps({"controller_addresses": valid_endpoints}))
+else:
+    # For all other clouds, do not specify addresses. Return empty JSON.
+    print(json.dumps({}))

--- a/justfile
+++ b/justfile
@@ -92,6 +92,32 @@ deploy: init
   tofu plan
   tofu apply -auto-approve
 
+# *Unfinished: does not run* as "deploy" above but using Python in-line
+deploy-python: init
+  #!/usr/bin/env python
+  import json
+  import subprocess
+
+  # Check if deploying on AWS
+  result = subprocess.check_output("juju show-controller --format json".split(),
+                                  stderr=subprocess.STDOUT, text=True)
+  juju_config = json.loads(result)
+  # Expect dictionary with single key corresponding to current controller name
+  controller_name = list(juju_config.keys())[0]
+  cloud = juju_config[controller_name]["details"]["cloud"]
+
+  if cloud == "aws":
+      # Filter out local IP addresses from list of all API endpoints
+      endpoints = juju_config[controller_name]["details"]["api-endpoints"]
+      valid_endpoints = ""
+      for endpoint in endpoints:
+          # Local IPs defined as those in 172.x and 252.x ranges
+          if not(endpoint.startswith(("172","252"))):
+              valid_endpoints += endpoint + ","
+      valid_endpoints = valid_endpoints.rstrip(",")
+
+  # TODO: appropriately set JUJU_CONTROLLER_ADDRESSES and run tofu plan/apply
+
 # destroy charmed hpc cluster deployed
 destroy:
   #!/usr/bin/env bash

--- a/main.tf
+++ b/main.tf
@@ -14,7 +14,17 @@
 
 # Deploy a minimal Charmed HPC cloud on LXD
 
-provider "juju" {}
+data "external" "controller_addresses" {
+  program = ["python3", "${path.module}/get_controller_addresses.py"]
+}
+
+provider "juju" {
+  controller_addresses = (
+    length(data.external.controller_addresses.result.controller_addresses) > 0
+    ? data.external.controller_addresses.result.controller_addresses
+    : null
+  )
+}
 
 resource "juju_model" "charmed-hpc" {
   name = var.model


### PR DESCRIPTION
Deploying on AWS intermittently fails with i/o timeouts as the Juju Terraform provider returns inaccessible local IP addresses in the list of API controllers. See: https://github.com/juju/terraform-provider-juju/issues/573

This PR contains three potential workarounds. Each determine if Juju's current cloud is 'aws' and set controller addresses to the non-local endpoint(s) if so. Details below:

**Draft 1:** Bash+regex in the `justfile`. 
**Draft 2:** Python+JSON parsing in the `justfile` (incomplete - does not run).
**Draft 3:** Standalone `get_controller_addresses.py` script used as an external data source in `main.tf`.

To graduate from draft status, a better check would be needed for invalid IPs (currently IPs starting `172` and `252` are considered invalid), and error handling improvements.

I'm opening this PR for comments - the plan is to look at the Terraform provider issue but thoughts on polishing one of these as a workaround in the meantime?