### PR TITLE
ci: add initial pipeline performing validation on PRs

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,37 @@
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+name: charmed-hpc-terraform tests
+on:
+  workflow_call:
+  pull_request:
+
+jobs:
+  inclusive-naming-check:
+    name: Inclusive naming check
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Run tests
+        uses: get-woke/woke-action@v0
+        with:
+          fail-on-error: true
+
+  validation-test:
+    name: Validation tests
+    runs-on: ubuntu-24.04
+    needs:
+      - inclusive-naming-check
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Install dependencies
+        run: |
+          sudo snap install --classic opentofu
+          sudo apt-get update
+          sudo apt-get install -y just
+      - name: Run tests
+        env:
+          TERM: xterm-256color
+        run: just check


### PR DESCRIPTION
Adds a CI pipeline to the repository for validating prospective pull requests.

Follows the standards of the `hpc-libs` and `slurm-charms` repositories, performing the `inclusive-naming-check` then a `validation-test`. Validation installs dependencies `opentofu` and `just`, then runs `just check`, as defined in `justfile`. Currently this is `tofu fmt -check -recursive`, to enforce formatting, and `tofu validate`, to check Terraform file syntax.