### PR TITLE
feat: add module to deploy and integrate grafana agent with slurmctld

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -54,16 +54,16 @@ variable "database-scale" {
   default     = 1
 }
 
+variable "grafana-agent-channel" {
+  description = "Channel to deploy grafana-agent-operator from."
+  type        = string
+  default     = "latest/stable"
+}
+
 variable "mysql-channel" {
   description = "Channel to deploy mysql from."
   type        = string
   default     = "8.0/stable"
-}
-
-variable "mysql-revision" {
-  description = "Revision of mysql to deploy from channel."
-  type        = number
-  default     = null
 }
 
 variable "mysql-scale" {


### PR DESCRIPTION
Changes:

* Replace `juju_applicaton` entry for `mysql` with the tf module from the upstream `mysql-operator` GitHub repository.

Docs:

* Added comments for what each section does.
* Removed mentions that the plan was originally used to deploy a small cluster on LXD. The main terraform plan can be used to deploy Charmed HPC pretty much anywhere. 