### PR TITLE
chore: remove `en` from documentation URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ tofu apply -auto-approve
 
 To learn more about the deployment and use of a Charmed HPC cluster, the following resources are available:
 
-* [Charmed HPC Documentation](https://canonical-charmed-hpc.readthedocs-hosted.com/en/latest)
+* [Charmed HPC Documentation](https://canonical-charmed-hpc.readthedocs-hosted.com/latest)
 * [Open an issue](https://github.com/charmed-hpc/charmed-hpc-terraform/issues/new?title=ISSUE+TITLE&body=*Please+describe+your+issue*)
 * [Ask a question on the Charmed HPC GitHub](https://github.com/orgs/charmed-hpc/discussions/categories/q-a)
 


### PR DESCRIPTION
# Pre-submission checklist

 * [x] I read and followed the CONTRIBUTING guidelines.
 * [x] I have insured that lint, typecheck, and unit tests complete successfully.

## Summary of changes

Small change to remove the language in the URL for our documentation.
cc @AshleyCliff.

## Docs
* [x] I have created a pull request to add or update relevant documentation in [charmed-hpc/docs](https://github.com/charmed-hpc/docs) or another documentation location.

The PR itself is a docs change.