### PR TITLE
chore: migrate repo to the canonical org

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-** @charmed-hpc/terraform-reviewers
+** @canonical/hpc-code-reviewers

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,30 @@
+# Pre-submission checklist
+
+ * [ ] I read and followed the CONTRIBUTING guidelines.
+ * [ ] I have ensured that lint, typecheck, and unit tests complete successfully.
+
+[//]: # (If you can't run the tests locally, create a draft PR to check against the CI pipeline. Once you verify that CI is passing, you can take your PR out of draft status. Please try running the tests locally first, before testing against the CI pipeline.)
+
+## Summary of changes
+
+[//]: # (Please summarize your commits here. For any complex or contentious changes, please also provide justifications.)
+
+
+
+#### Related Issues, PRs, and Discussions
+
+[//]: # (Please link to related issues, pull requests, and discussions here. If your PR has no related issues, PRs, or discussions, please provide a justification for this PR here instead.)
+
+
+
+## Docs
+
+* [ ] I have created a pull request to add or update relevant documentation in [charmed-hpc/docs](https://github.com/charmed-hpc/docs) or another documentation location.
+
+[//]: # (If documentation has been updated or added in a location other than charmed-hpc/docs, please note the location here.)
+
+Or:
+
+* [ ] I confirm that this pull request requires no changes or additions to documentation.
+
+[//]: # (If your PR does not require changes or additions to documentation, please write your justification here.)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,12 +7,10 @@ Before you start working on your contribution, please familiarize yourself with 
 HPC project's contributing guide]. After you've gone through the main contributing guide,
 you can use this guide for specific information on contributing to the `charmed-hpc-terraform` repository.
 
-Have any questions? Feel free to ask them in the [Ubuntu High-Performance Computing Matrix chat]
-or on [GitHub Discussions].
+Have any questions? Feel free to ask them in the [Ubuntu High-Performance Computing Matrix chat].
 
-[Charmed HPC project's contributing guide]: https://github.com/charmed-hpc/docs/blob/main/CONTRIBUTING.md
+[Charmed HPC project's contributing guide]: https://github.com/canonical/charmed-hpc-docs/blob/main/CONTRIBUTING.md
 [Ubuntu High-Performance Computing Matrix chat]: https://matrix.to/#/#hpc:ubuntu.com
-[GitHub Discussions]: https://github.com/orgs/charmed-hpc/discussions/categories/support
 
 ## Hacking on `charmed-hpc-terraform`
 
@@ -84,4 +82,3 @@ and you make changes to that file in 2025, update the copyright year in the file
 ```text
 Copyright 2023-2025 Canonical Ltd.
 ```
-

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ module "mysql" {
 }
 
 module "slurm" {
-  source = "git::https://github.com/charmed-hpc/charmed-hpc-terraform//modules/slurm"
+  source = "git::https://github.com/canonical/charmed-hpc-terraform//modules/slurm"
 
   model_name = juju_model.charmed-hpc.name
   database_backend = {
@@ -105,8 +105,7 @@ tofu apply -auto-approve
 To learn more about the deployment and use of a Charmed HPC cluster, the following resources are available:
 
 * [Charmed HPC Documentation](https://canonical-charmed-hpc.readthedocs-hosted.com/latest)
-* [Open an issue](https://github.com/charmed-hpc/charmed-hpc-terraform/issues/new?title=ISSUE+TITLE&body=*Please+describe+your+issue*)
-* [Ask a question on the Charmed HPC GitHub](https://github.com/orgs/charmed-hpc/discussions/categories/q-a)
+* [Open an issue](https://github.com/canonical/charmed-hpc-terraform/issues/new?title=ISSUE+TITLE&body=*Please+describe+your+issue*)
 
 ## 🛠️ Development
 
@@ -128,7 +127,6 @@ Here’s some links to help you get started with joining the community:
 * [Contributing guidelines](./CONTRIBUTING.md)
 * [Join the conversation on Matrix](https://matrix.to/#/#hpc:ubuntu.com)
 * [Get the latest news on Discourse](https://discourse.ubuntu.com/c/hpc/151)
-* [Ask and answer questions on GitHub](https://github.com/orgs/charmed-hpc/discussions/categories/q-a)
 
 ## 📋 License
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -14,7 +14,7 @@ The preferred way to report a security issue is through [GitHub Security Advisor
 [Privately reporting a security vulnerability][how-to-sec-vuln] for instructions on how to report a security vulnerability
 using GitHub's security advisory feature.
 
-[gsa]: https://github.com/charmed-hpc/charmed-hpc-terraform/security/advisories/new
+[gsa]: https://github.com/canonical/charmed-hpc-terraform/security/advisories/new
 [how-to-sec-vuln]: https://docs.github.com/en/code-security/security-advisories/guidance-on-reporting-and-writing/privately-reporting-a-security-vulnerability
 
 You may also send email to [security@ubuntu.com](mailto:security@ubuntu.com). Email may optionally be encrypted to OpenPGP

--- a/examples/nfs/aws/main.tf
+++ b/examples/nfs/aws/main.tf
@@ -152,7 +152,7 @@ resource "juju_model" "charmed-hpc" {
 }
 
 module "nfs-share" {
-  source     = "git::https://github.com/charmed-hpc/charmed-hpc-terraform//modules/nfs/aws"
+  source     = "git::https://github.com/canonical/charmed-hpc-terraform//modules/nfs/aws"
   name       = "nfs-share"
   vpc_id     = module.nfs-vpc.vpc_id
   subnet_id  = module.nfs-vpc.private_subnets[0]

--- a/examples/nfs/azure/main.tf
+++ b/examples/nfs/azure/main.tf
@@ -77,7 +77,7 @@ resource "juju_model" "charmed-hpc" {
 }
 
 module "nfs-share" {
-  source = "git::https://github.com/charmed-hpc/charmed-hpc-terraform//modules/nfs/azure"
+  source = "git::https://github.com/canonical/charmed-hpc-terraform//modules/nfs/azure"
 
   name                = "nfs-share"
   resource_group_name = azurerm_resource_group.nfs-group.name

--- a/examples/slurm/main.tf
+++ b/examples/slurm/main.tf
@@ -24,7 +24,7 @@ module "mysql" {
 }
 
 module "slurm" {
-  source = "git::https://github.com/charmed-hpc/charmed-hpc-terraform//modules/slurm"
+  source = "git::https://github.com/canonical/charmed-hpc-terraform//modules/slurm"
 
   model_name = juju_model.charmed-hpc.name
   database_backend = {

--- a/modules/nfs/aws/main.tf
+++ b/modules/nfs/aws/main.tf
@@ -64,7 +64,7 @@ module "efs" {
   }
 }
 
-// TODO: Modify https://github.com/charmed-hpc/filesystem-charms//charms/filesystem-client/terraform
+// TODO: Modify https://github.com/canonical/filesystem-charms//charms/filesystem-client/terraform
 // so that it allows machine placement.
 resource "juju_machine" "nfs-server-proxy" {
   model     = var.model_name
@@ -91,7 +91,7 @@ resource "juju_application" "nfs-server-proxy" {
 }
 
 module "filesystem-client" {
-  source = "git::https://github.com/charmed-hpc/filesystem-charms//charms/filesystem-client/terraform"
+  source = "git::https://github.com/canonical/filesystem-charms//charms/filesystem-client/terraform"
 
   app_name   = "${var.name}-client"
   model_name = var.model_name

--- a/modules/nfs/azure/main.tf
+++ b/modules/nfs/azure/main.tf
@@ -92,7 +92,7 @@ resource "azurerm_private_dns_zone_virtual_network_link" "nfs" {
 }
 
 module "nfs-server-proxy" {
-  source = "git::https://github.com/charmed-hpc/filesystem-charms//charms/nfs-server-proxy/terraform"
+  source = "git::https://github.com/canonical/filesystem-charms//charms/nfs-server-proxy/terraform"
 
   app_name   = "${var.name}-server"
   model_name = var.model_name
@@ -108,7 +108,7 @@ module "nfs-server-proxy" {
 }
 
 module "filesystem-client" {
-  source = "git::https://github.com/charmed-hpc/filesystem-charms//charms/filesystem-client/terraform"
+  source = "git::https://github.com/canonical/filesystem-charms//charms/filesystem-client/terraform"
 
   app_name   = "${var.name}-client"
   model_name = var.model_name

--- a/modules/nfs/gcp/main.tf
+++ b/modules/nfs/gcp/main.tf
@@ -51,7 +51,7 @@ resource "juju_application" "nfs-server-proxy" {
 }
 
 module "filesystem-client" {
-  source = "git::https://github.com/charmed-hpc/filesystem-charms//charms/filesystem-client/terraform"
+  source = "git::https://github.com/canonical/filesystem-charms//charms/filesystem-client/terraform"
 
   app_name   = "${var.name}-client"
   model_name = var.model_name

--- a/modules/slurm/main.tf
+++ b/modules/slurm/main.tf
@@ -24,7 +24,7 @@ data "juju_application" "mysql" {
 # Setup control plane
 
 module "slurmctld" {
-  source = "git::https://github.com/charmed-hpc/slurm-charms//charms/slurmctld/terraform"
+  source = "git::https://github.com/canonical/slurm-charms//charms/slurmctld/terraform"
 
   model_name  = data.juju_model.this.name
   app_name    = var.controller.app_name
@@ -35,7 +35,7 @@ module "slurmctld" {
 }
 
 module "slurmdbd" {
-  source = "git::https://github.com/charmed-hpc/slurm-charms//charms/slurmdbd/terraform"
+  source = "git::https://github.com/canonical/slurm-charms//charms/slurmdbd/terraform"
 
   model_name  = data.juju_model.this.name
   app_name    = var.database.app_name
@@ -46,7 +46,7 @@ module "slurmdbd" {
 }
 
 module "slurmrestd" {
-  source = "git::https://github.com/charmed-hpc/slurm-charms//charms/slurmrestd/terraform"
+  source = "git::https://github.com/canonical/slurm-charms//charms/slurmrestd/terraform"
 
   model_name  = data.juju_model.this.name
   app_name    = var.rest_api.app_name
@@ -57,7 +57,7 @@ module "slurmrestd" {
 }
 
 module "sackd" {
-  source = "git::https://github.com/charmed-hpc/slurm-charms//charms/sackd/terraform"
+  source = "git::https://github.com/canonical/slurm-charms//charms/sackd/terraform"
 
   model_name  = data.juju_model.this.name
   app_name    = var.kiosk.app_name
@@ -127,7 +127,7 @@ resource "juju_integration" "slurmdbd-to-mysql" {
 
 module "slurmd_partitions" {
   for_each = var.compute_partitions
-  source   = "git::https://github.com/charmed-hpc/slurm-charms//charms/slurmd/terraform"
+  source   = "git::https://github.com/canonical/slurm-charms//charms/slurmd/terraform"
 
   model_name  = data.juju_model.this.name
   app_name    = each.key


### PR DESCRIPTION
Migrate all our references to the charmed-hpc org to the canonical org equivalent.